### PR TITLE
Remove redundant resignFirstResponder()

### DIFF
--- a/Sources/NextResponderTextField.swift
+++ b/Sources/NextResponderTextField.swift
@@ -64,12 +64,8 @@ public class NextResponderTextField: UITextField {
     */
     func actionKeyboardButtonTapped(sender: UITextField) {
         switch nextResponderField {
-        case let button as UIButton:
-            if button.isEnabled {
-                button.sendActions(for: .touchUpInside)
-            } else {
-                resignFirstResponder()
-            }
+        case let button as UIButton where button.isEnabled:
+            button.sendActions(for: .touchUpInside)
         case .some(let responder):
             responder.becomeFirstResponder()
         default:


### PR DESCRIPTION
`if button.isEnabled` can be turned into a `where` because `resignFirstResponder()` in `else` is already expected in the `default` case.
