### PR TITLE
Remove class name in selector

### DIFF
--- a/Sources/NextResponderTextField.swift
+++ b/Sources/NextResponderTextField.swift
@@ -54,7 +54,7 @@ public class NextResponderTextField: UITextField {
     Sets up the view.
     */
     func setUp() {
-        addTarget(self, action: #selector(NextResponderTextField.actionKeyboardButtonTapped(sender:)), for: .editingDidEndOnExit)
+        addTarget(self, action: #selector(actionKeyboardButtonTapped(sender:)), for: .editingDidEndOnExit)
     }
 
     /**


### PR DESCRIPTION
`NextResponderTextField` is not necessary in `addTarget(self, action: #selector(NextResponderTextField.actionKeyboardButtonTapped(sender:)), for: .editingDidEndOnExit)`

The less code, the better 🎉
